### PR TITLE
Make the generator accessible

### DIFF
--- a/lib/time_turner.rb
+++ b/lib/time_turner.rb
@@ -6,6 +6,7 @@ class TimeTurner
   #
   # @return [Time]
   attr_reader :big_bang
+  attr_reader :generator
   attr_reader :log
 
   # Initialize TimeTurner pseudo-random generator with a seed value


### PR DESCRIPTION
Use case : 
```
Mentor.company_sizes.keys.except('unknown').sample(random: time_turner.generator),
```
instead of 
```
Mentor.company_sizes.keys.except('unknown').sample(random: time_turner.instance_variable_get(:@generator)),
```