### PR TITLE
fix: Only load version number in gemspec file to avoid install problems

### DIFF
--- a/time_turner.gemspec
+++ b/time_turner.gemspec
@@ -1,7 +1,7 @@
 
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "time_turner"
+require_relative 'lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "time_turner"


### PR DESCRIPTION
There was an error while loading `time_turner.gemspec`: cannot load such file -- active_support/core_ext/integer
"Le truc c'est que pour installer la gem il faut loader le gemspec"